### PR TITLE
Fix `env cors` prompt

### DIFF
--- a/src/cli/env/cors.ts
+++ b/src/cli/env/cors.ts
@@ -151,6 +151,8 @@ export const handler = async (argv: Arguments<Options>) => {
     (argv.selected as string[]) || (allowedCorsOrigins as string[]) || [];
   let addMore = true;
 
+  const addNewMsg = 'Add a new CORS origin';
+
   const { origins } = await Enquirer.prompt<{
     origins: string;
   }>([
@@ -159,7 +161,7 @@ export const handler = async (argv: Arguments<Options>) => {
       name: 'origins',
       message:
         'Define Selected Origins\n (use the arrows to navigate and the space bar to select)',
-      choices: [...selected, 'Add a new CORS origin'],
+      choices: [...selected, addNewMsg],
       initial: selected,
     },
   ]);
@@ -168,7 +170,7 @@ export const handler = async (argv: Arguments<Options>) => {
     if (origins.length === 0) {
       return;
     }
-    if (origins.includes('Add a new CORS origin')) {
+    if (origins.includes(addNewMsg)) {
       const form = await promptOrigin();
       selected.push(form.origin);
       addMore = form.addMore;

--- a/src/cli/env/cors.ts
+++ b/src/cli/env/cors.ts
@@ -2,9 +2,6 @@ import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import Enquirer from 'enquirer';
-import { ar } from 'date-fns/locale';
-import { error } from 'console';
-import chalk from 'chalk';
 import { API, PATCH } from '../../lib/index.js';
 import { obfuscateArgv, println, printlnSuccess } from '../../lib/util.js';
 import {
@@ -107,16 +104,16 @@ export const handler = async (argv: Arguments<Options>) => {
       message: 'Choose allowed API origins ',
       choices: [
         {
-          name: 'Allow all origins',
-          value: 'all',
+          message: 'Allow all origins',
+          name: 'all',
         },
         {
-          name: 'Selected Origins',
-          value: 'selected',
+          message: 'Selected Origins',
+          name: 'selected',
         },
         {
-          name: 'Dashboard only',
-          value: 'dashboard',
+          message: 'Dashboard only',
+          name: 'dashboard',
         },
       ],
       initial: () => {
@@ -162,7 +159,7 @@ export const handler = async (argv: Arguments<Options>) => {
       name: 'origins',
       message:
         'Define Selected Origins\n (use the arrows to navigate and the space bar to select)',
-      choices: [...selected, 'Add a new origin'],
+      choices: [...selected, 'Add a new CORS origin'],
       initial: selected,
     },
   ]);


### PR DESCRIPTION
## I want to merge this PR because 

- it fixes the `env cors` prompt caused by strange handling of choice options by enquirer
- if extracts to const the `Add a new CORS origin`
 
## Related (issues, PRs, topics)

- #688 

## Steps to test feature

- `saler env cors`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
