### PR TITLE
Unify array option naming

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,5 +2,5 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 node './dist/saleor.js' dev docs
-git add docs/README.md
+git add docs/
 npx lint-staged

--- a/docs/README.md
+++ b/docs/README.md
@@ -683,13 +683,13 @@ Options:
       --json             Output the data as JSON  [boolean] [default: false]
       --short            Output data as text  [boolean] [default: false]
   -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
-      --origin           Allowed domains  [array]
+      --origins          Allowed domains  [array]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
 
 Examples:
   saleor env origins
-  saleor env origins my-environment --origin=https://trusted-origin.com
+  saleor env origins my-environment --origins=https://trusted-origin.com
 ```
 
 #### environment populate

--- a/docs/cli/commands/environment.mdx
+++ b/docs/cli/commands/environment.mdx
@@ -240,13 +240,13 @@ Options:
       --json             Output the data as JSON  [boolean] [default: false]
       --short            Output data as text  [boolean] [default: false]
   -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
-      --origin           Allowed domains  [array]
+      --origins          Allowed domains  [array]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
 
 Examples:
   saleor env origins
-  saleor env origins my-environment --origin=https://trusted-origin.com
+  saleor env origins my-environment --origins=https://trusted-origin.com
 ```
 
 #### environment populate

--- a/src/cli/env/origins.ts
+++ b/src/cli/env/origins.ts
@@ -22,14 +22,14 @@ export const builder: CommandBuilder = (_) =>
     demandOption: false,
     desc: 'key of the environment',
   })
-    .option('origin', {
+    .option('origins', {
       type: 'array',
       demandOption: false,
       desc: 'Allowed domains',
     })
     .example('saleor env origins', '')
     .example(
-      'saleor env origins my-environment --origin=https://trusted-origin.com',
+      'saleor env origins my-environment --origins=https://trusted-origin.com',
       '',
     );
 
@@ -39,10 +39,10 @@ export const handler = async (argv: Arguments<Options>) => {
   const { allowed_client_origins: allowedClientOrigins } =
     await getEnvironment(argv);
 
-  if (((argv.origin as undefined | string[]) || [])?.length > 0) {
+  if (((argv.origins as undefined | string[]) || [])?.length > 0) {
     await PATCH(API.Environment, argv, {
       json: {
-        allowed_client_origins: argv.origin,
+        allowed_client_origins: argv.origins,
       },
     });
 


### PR DESCRIPTION
## I want to merge this PR because 

- it changes the `origin` option to `origins` as a unification to plural form for array options

## Related (issues, PRs, topics)

- NA

## Steps to test feature

- `saleor env origins --origins=https://yourdomain.com`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [x] Added documentation if public changes are introduced
- [ ] Added tests for my code
