### PR TITLE
Use instance with `graphql` suffix, add examples

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -537,6 +537,10 @@ Options:
   -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor env clear my-environment
+  saleor env clear my-environment --organization=organization-slug
 ```
 
 #### environment cors
@@ -915,6 +919,10 @@ Options:
   -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor backup list
+  saleor backup list --organization="organization-slug" --environment="env-id-or-name"
 ```
 
 #### backup create
@@ -962,6 +970,11 @@ Options:
   -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor backup show
+  saleor backup show backup-key
+  saleor backup show backup-key --organization="organization-slug" --environment="env-id-or-name"
 ```
 
 #### backup remove
@@ -987,6 +1000,11 @@ Options:
       --force            skip confirmation prompt  [boolean]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor backup remove
+  saleor backup remove backup-key --force
+  saleor backup remove backup-key --force --organization="organization-slug" --environment="env-id-or-name"
 ```
 
 #### backup restore
@@ -1010,6 +1028,11 @@ Options:
       --skip-webhooks-update  skip webhooks update prompt  [boolean]
   -V, --version               Show version number  [boolean]
   -h, --help                  Show help  [boolean]
+
+Examples:
+  saleor backup restore
+  saleor backup restore --from="backup-key" --skip-webhooks-update
+  saleor backup restore --from="backup-key" --skip-webhooks-update --organization="organization-slug" --environment="env-id-or-name"
 ```
 
 ### task
@@ -1572,15 +1595,15 @@ saleor app [command]
 Manage Saleor Apps
 
 Commands:
-  saleor app list               List installed Saleor Apps for an environment
-  saleor app install            Install a Saleor App by URL
-  saleor app uninstall <appId>  Uninstall a Saleor App by ID. You need to provide `appId`. List available apps and their IDs with `saleor app list`.
-  saleor app create [name]      Create a new Saleor Local App
-  saleor app tunnel [port]      Expose your Saleor app remotely with ngrok tunnel
-  saleor app token              Create a Saleor App token
-  saleor app permission         Add or remove permission for a Saleor App
-  saleor app template [name]    Create an App with Saleor App Template
-  saleor app remove [app-id]    Create a new Saleor Local App
+  saleor app list                List installed Saleor Apps for an environment
+  saleor app install             Install a Saleor App by URL
+  saleor app uninstall <app-id>  Uninstall a Saleor App by ID. You need to provide `appId`. List available apps and their IDs with `saleor app list`.
+  saleor app create [name]       Create a new Saleor Local App
+  saleor app tunnel [port]       Expose your Saleor app remotely with ngrok tunnel
+  saleor app token               Create a Saleor App token
+  saleor app permission          Add or remove permission for a Saleor App
+  saleor app template [name]     Create an App with Saleor App Template
+  saleor app remove [app-id]     Create a new Saleor Local App
 
 Options:
       --json             Output the data as JSON  [boolean] [default: false]
@@ -1609,6 +1632,9 @@ Options:
   -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor app list
 ```
 
 #### app install
@@ -1649,9 +1675,12 @@ $ saleor app uninstall --help
 Help output:
 
 ```
-saleor app uninstall <appId>
+saleor app uninstall <app-id>
 
 Uninstall a Saleor App by ID. You need to provide `appId`. List available apps and their IDs with `saleor app list`.
+
+Positionals:
+  app-id  The Saleor App id  [string] [required]
 
 Options:
       --json             Output the data as JSON  [boolean] [default: false]
@@ -1659,6 +1688,10 @@ Options:
   -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor app uninstall app-id
+  saleor app uninstall app-id --organization=organization-slug --environment=env-id-or-name
 ```
 
 #### app create
@@ -1743,6 +1776,11 @@ Options:
       --app-id           The Saleor App id  [string]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor app token
+  saleor app token --app-id="app-id"
+  saleor app token --app-id="app-id=" --organization="organization-slug" --environment="env-id-or-name"
 ```
 
 #### app permission

--- a/docs/cli/commands/app.mdx
+++ b/docs/cli/commands/app.mdx
@@ -16,15 +16,15 @@ saleor app [command]
 Manage Saleor Apps
 
 Commands:
-  saleor app list               List installed Saleor Apps for an environment
-  saleor app install            Install a Saleor App by URL
-  saleor app uninstall <appId>  Uninstall a Saleor App by ID. You need to provide `appId`. List available apps and their IDs with `saleor app list`.
-  saleor app create [name]      Create a new Saleor Local App
-  saleor app tunnel [port]      Expose your Saleor app remotely with ngrok tunnel
-  saleor app token              Create a Saleor App token
-  saleor app permission         Add or remove permission for a Saleor App
-  saleor app template [name]    Create an App with Saleor App Template
-  saleor app remove [app-id]    Create a new Saleor Local App
+  saleor app list                List installed Saleor Apps for an environment
+  saleor app install             Install a Saleor App by URL
+  saleor app uninstall <app-id>  Uninstall a Saleor App by ID. You need to provide `appId`. List available apps and their IDs with `saleor app list`.
+  saleor app create [name]       Create a new Saleor Local App
+  saleor app tunnel [port]       Expose your Saleor app remotely with ngrok tunnel
+  saleor app token               Create a Saleor App token
+  saleor app permission          Add or remove permission for a Saleor App
+  saleor app template [name]     Create an App with Saleor App Template
+  saleor app remove [app-id]     Create a new Saleor Local App
 
 Options:
       --json             Output the data as JSON  [boolean] [default: false]
@@ -53,6 +53,9 @@ Options:
   -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor app list
 ```
 
 #### app install
@@ -93,9 +96,12 @@ $ saleor app uninstall --help
 Help output:
 
 ```
-saleor app uninstall <appId>
+saleor app uninstall <app-id>
 
 Uninstall a Saleor App by ID. You need to provide `appId`. List available apps and their IDs with `saleor app list`.
+
+Positionals:
+  app-id  The Saleor App id  [string] [required]
 
 Options:
       --json             Output the data as JSON  [boolean] [default: false]
@@ -103,6 +109,10 @@ Options:
   -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor app uninstall app-id
+  saleor app uninstall app-id --organization=organization-slug --environment=env-id-or-name
 ```
 
 #### app create
@@ -187,6 +197,11 @@ Options:
       --app-id           The Saleor App id  [string]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor app token
+  saleor app token --app-id="app-id"
+  saleor app token --app-id="app-id=" --organization="organization-slug" --environment="env-id-or-name"
 ```
 
 #### app permission

--- a/docs/cli/commands/backup.mdx
+++ b/docs/cli/commands/backup.mdx
@@ -49,6 +49,10 @@ Options:
   -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor backup list
+  saleor backup list --organization="organization-slug" --environment="env-id-or-name"
 ```
 
 #### backup create
@@ -96,6 +100,11 @@ Options:
   -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor backup show
+  saleor backup show backup-key
+  saleor backup show backup-key --organization="organization-slug" --environment="env-id-or-name"
 ```
 
 #### backup remove
@@ -121,6 +130,11 @@ Options:
       --force            skip confirmation prompt  [boolean]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor backup remove
+  saleor backup remove backup-key --force
+  saleor backup remove backup-key --force --organization="organization-slug" --environment="env-id-or-name"
 ```
 
 #### backup restore
@@ -144,4 +158,9 @@ Options:
       --skip-webhooks-update  skip webhooks update prompt  [boolean]
   -V, --version               Show version number  [boolean]
   -h, --help                  Show help  [boolean]
+
+Examples:
+  saleor backup restore
+  saleor backup restore --from="backup-key" --skip-webhooks-update
+  saleor backup restore --from="backup-key" --skip-webhooks-update --organization="organization-slug" --environment="env-id-or-name"
 ```

--- a/docs/cli/commands/environment.mdx
+++ b/docs/cli/commands/environment.mdx
@@ -94,6 +94,10 @@ Options:
   -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor env clear my-environment
+  saleor env clear my-environment --organization=organization-slug
 ```
 
 #### environment cors

--- a/src/cli/app/create.ts
+++ b/src/cli/app/create.ts
@@ -58,15 +58,14 @@ export const handler = async (argv: Arguments<any>) => {
   debug(`Using the name: ${name}`);
 
   const { instance } = argv;
-  const endpoint = `${instance}/graphql/`;
   const headers = await Config.getBearerHeader();
-  const availablePermissions = await getPermissionsEnum(endpoint);
+  const availablePermissions = await getPermissionsEnum(instance);
 
   const permissions =
     argv.permissions ?? (await choosePermissions(availablePermissions, 0));
 
   const { data }: any = await got
-    .post(endpoint, {
+    .post(instance, {
       headers,
       json: {
         query: print(AppCreate),

--- a/src/cli/app/list.ts
+++ b/src/cli/app/list.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import Debug from 'debug';
 import got from 'got';
 import { print } from 'graphql';
-import { Arguments } from 'yargs';
+import { Arguments, CommandBuilder } from 'yargs';
 
 import { GetApps } from '../../generated/graphql.js';
 import { Config } from '../../lib/config.js';
@@ -24,19 +24,19 @@ const debug = Debug('saleor-cli:app:list');
 export const command = 'list';
 export const desc = 'List installed Saleor Apps for an environment';
 
+export const builder: CommandBuilder = (_) => _.example('saleor app list', '');
+
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
 
   const { ux: cli } = CliUx;
   const headers = await Config.getBearerHeader();
 
-  const { instance } = argv;
-  const endpoint = `${instance}/graphql/`;
-  debug(`Saleor endpoint: ${endpoint}`);
+  const { instance, json } = argv;
 
   debug('Fetching Saleor Apps');
   const { data }: any = await got
-    .post(endpoint, {
+    .post(instance, {
       headers,
       json: {
         query: print(GetApps),
@@ -45,11 +45,11 @@ export const handler = async (argv: Arguments<Options>) => {
     })
     .json();
 
-  const apps = getAppsFromResult(data, argv.json);
+  const apps = getAppsFromResult(data, json);
 
   const collection: any[] = apps.map(({ node }: any) => ({ ...node }));
 
-  if (argv.json) {
+  if (json) {
     console.log(JSON.stringify(collection, null, 2));
     return;
   }

--- a/src/cli/app/permission.ts
+++ b/src/cli/app/permission.ts
@@ -47,17 +47,15 @@ export const handler = async (argv: Arguments<Options>) => {
   printContext(argv);
 
   const { instance, appId, json } = argv;
-  const endpoint = `${instance}/graphql/`;
-  debug(`Saleor endpoint: ${endpoint}`);
 
-  const { app, apps } = await getSaleorApp({ endpoint, appId, json });
+  const { app, apps } = await getSaleorApp({ instance, appId, json });
   const permissions =
-    argv.permissions ?? (await getPermissions(endpoint, apps, app));
+    argv.permissions ?? (await getPermissions(instance, apps, app));
 
   debug(`Attempting to update the permissions for the app: ${app}`);
   const headers = await Config.getBearerHeader();
   await got
-    .post(endpoint, {
+    .post(instance, {
       headers,
       json: {
         query: print(AppUpdate),
@@ -83,7 +81,7 @@ export const choosePermissions = async (choices: any, initial: number) => {
   return permissions;
 };
 
-export const getPermissionsEnum = async (endpoint: string) => {
+export const getPermissionsEnum = async (instance: string) => {
   const headers = await Config.getBearerHeader();
   debug('Fetching permission enum list');
   const {
@@ -91,7 +89,7 @@ export const getPermissionsEnum = async (endpoint: string) => {
       __type: { enumValues },
     },
   }: any = await got
-    .post(endpoint, {
+    .post(instance, {
       headers,
       json: {
         query: print(GetPermissionEnum),
@@ -104,7 +102,7 @@ export const getPermissionsEnum = async (endpoint: string) => {
 };
 
 const getPermissions = async (
-  endpoint: string,
+  instance: string,
   apps: any,
   app: string | undefined,
 ) => {
@@ -113,7 +111,7 @@ const getPermissions = async (
     process.exit(0);
   }
 
-  const enumValues = await getPermissionsEnum(endpoint);
+  const enumValues = await getPermissionsEnum(instance);
 
   const choices2 = enumValues.map((node: any) => ({
     name: node.name,

--- a/src/cli/app/remove.ts
+++ b/src/cli/app/remove.ts
@@ -39,8 +39,7 @@ export const handler = async (argv: Arguments<any>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
 
   const { instance, appId, json } = argv;
-  const endpoint = `${instance}/graphql/`;
-  const { app } = await getSaleorApp({ endpoint, appId, json });
+  const { app } = await getSaleorApp({ instance, appId, json });
 
   const proceed = await confirmRemoval(argv, `app ${app}`);
 
@@ -48,7 +47,7 @@ export const handler = async (argv: Arguments<any>) => {
     const headers = await Config.getBearerHeader();
 
     const { data }: any = await got
-      .post(endpoint, {
+      .post(instance, {
         headers,
         json: {
           query: print(AppDelete),

--- a/src/cli/app/uninstall.ts
+++ b/src/cli/app/uninstall.ts
@@ -17,11 +17,22 @@ import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:app:uninstall');
 
-export const command = 'uninstall <appId>';
+export const command = 'uninstall <app-id>';
 export const desc =
   'Uninstall a Saleor App by ID. You need to provide `appId`. List available apps and their IDs with `saleor app list`.';
 
-export const builder: CommandBuilder = (_) => _;
+export const builder: CommandBuilder = (_) =>
+  _.positional('app-id', {
+    type: 'string',
+    demandOption: false,
+    desc: 'The Saleor App id',
+  })
+
+    .example('saleor app uninstall app-id', '')
+    .example(
+      'saleor app uninstall app-id --organization=organization-slug --environment=env-id-or-name',
+      '',
+    );
 
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));

--- a/src/cli/backup/list.ts
+++ b/src/cli/backup/list.ts
@@ -1,7 +1,7 @@
 import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
 import Debug from 'debug';
-import { Arguments } from 'yargs';
+import { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
 import {
@@ -15,6 +15,12 @@ const debug = Debug('saleor-cli:backup:list');
 
 export const command = 'list [key|environment]';
 export const desc = 'List backups of the environment';
+
+export const builder: CommandBuilder = (_) =>
+  _.example('saleor backup list', '').example(
+    'saleor backup list --organization="organization-slug" --environment="env-id-or-name"',
+    '',
+  );
 
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));

--- a/src/cli/backup/remove.ts
+++ b/src/cli/backup/remove.ts
@@ -20,10 +20,17 @@ export const builder: CommandBuilder = (_) =>
     type: 'string',
     demandOption: false,
     desc: 'key of the backup',
-  }).option('force', {
-    type: 'boolean',
-    desc: 'skip confirmation prompt',
-  });
+  })
+    .option('force', {
+      type: 'boolean',
+      desc: 'skip confirmation prompt',
+    })
+    .example('saleor backup remove', '')
+    .example('saleor backup remove backup-key --force', '')
+    .example(
+      'saleor backup remove backup-key --force --organization="organization-slug" --environment="env-id-or-name"',
+      '',
+    );
 
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));

--- a/src/cli/backup/restore.ts
+++ b/src/cli/backup/restore.ts
@@ -21,11 +21,21 @@ export const builder: CommandBuilder = (_) =>
     type: 'string',
     demandOption: false,
     desc: 'the key of the snapshot',
-  }).option('skip-webhooks-update', {
-    type: 'boolean',
-    demandOption: false,
-    desc: 'skip webhooks update prompt',
-  });
+  })
+    .option('skip-webhooks-update', {
+      type: 'boolean',
+      demandOption: false,
+      desc: 'skip webhooks update prompt',
+    })
+    .example('saleor backup restore', '')
+    .example(
+      'saleor backup restore --from="backup-key" --skip-webhooks-update',
+      '',
+    )
+    .example(
+      'saleor backup restore --from="backup-key" --skip-webhooks-update --organization="organization-slug" --environment="env-id-or-name"',
+      '',
+    );
 
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
@@ -55,9 +65,7 @@ export const handler = async (argv: Arguments<Options>) => {
 
   if (update) {
     const { instance } = argv;
-    const endpoint = `${instance}/graphql/`;
-    debug(`Saleor endpoint: ${endpoint}`);
-    await updateWebhook(endpoint, argv.json);
+    await updateWebhook(instance, argv.json);
   }
 };
 

--- a/src/cli/backup/show.ts
+++ b/src/cli/backup/show.ts
@@ -1,7 +1,7 @@
 import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
-import { API, GET, NoCommandBuilderSetup } from '../../lib/index.js';
+import { API, GET } from '../../lib/index.js';
 import { obfuscateArgv, showResult } from '../../lib/util.js';
 import { Options } from '../../types.js';
 
@@ -10,7 +10,13 @@ const debug = Debug('saleor-cli:backup:show');
 export const command = 'show [backup|backup-key]';
 export const desc = 'Show a specific backup';
 
-export const builder: CommandBuilder = NoCommandBuilderSetup;
+export const builder: CommandBuilder = (_) =>
+  _.example('saleor backup show', '')
+    .example('saleor backup show backup-key', '')
+    .example(
+      'saleor backup show backup-key --organization="organization-slug" --environment="env-id-or-name"',
+      '',
+    );
 
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));

--- a/src/cli/env/clear.ts
+++ b/src/cli/env/clear.ts
@@ -16,7 +16,12 @@ export const builder: CommandBuilder = (_) =>
     type: 'string',
     demandOption: false,
     desc: 'key of the environment',
-  });
+  })
+    .example('saleor env clear my-environment', '')
+    .example(
+      'saleor env clear my-environment --organization=organization-slug',
+      '',
+    );
 
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));

--- a/src/cli/env/create.ts
+++ b/src/cli/env/create.ts
@@ -101,8 +101,8 @@ export const handler = async (argv: Arguments<CommandOptions>) => {
 
     debug('updating the webhooks');
     if (update) {
-      const endpoint = `https://${result.domain}/graphql/`;
-      await updateWebhook(endpoint, argv.json);
+      const instance = `https://${result.domain}/graphql/`;
+      await updateWebhook(instance, argv.json);
     }
   }
 };

--- a/src/cli/storefront/deploy.ts
+++ b/src/cli/storefront/deploy.ts
@@ -65,11 +65,8 @@ export const handler = async (argv: Arguments<Deploy>) => {
   const vercel = new Vercel(vercelToken);
   const repoUrl = await getRepoUrl(name, argv.githubPrompt);
 
-  const endpoint = `${argv.instance!}/graphql/`;
-  debug(`Saleor endpoint: ${endpoint}`);
-
   const envs = {
-    SALEOR_API_URL: endpoint,
+    SALEOR_API_URL: argv.instance,
   };
 
   console.log('\nDeploying Storefront to Vercel');

--- a/src/cli/trigger.ts
+++ b/src/cli/trigger.ts
@@ -22,7 +22,7 @@ export const builder: CommandBuilder = (_) =>
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
 
-  const { id } = argv;
+  const { id, instance } = argv;
   let { event } = argv;
 
   const {
@@ -63,8 +63,6 @@ export const handler = async (argv: Arguments<Options>) => {
     `\n  GraphQL Operation for ${chalk.underline(event)} available\n`,
   );
 
-  const { instance } = argv;
-  const endpoint = `${instance}/graphql/`;
   const headers = await Config.getBearerHeader();
 
   // FIXME
@@ -73,7 +71,7 @@ export const handler = async (argv: Arguments<Options>) => {
 
   try {
     const result = await request(
-      endpoint,
+      instance,
       (SaleorGraphQL as any)[operationName],
       {
         id,

--- a/src/cli/webhook/create.ts
+++ b/src/cli/webhook/create.ts
@@ -119,11 +119,10 @@ export const handler = async (argv: Arguments<Options>) => {
   ]);
 
   const { instance } = argv;
-  const endpoint = `${instance}/graphql/`;
   const headers = await Config.getBearerHeader();
 
   const { data }: any = await got
-    .post(endpoint, {
+    .post(instance, {
       headers,
       json: {
         query: print(WebhookCreate),

--- a/src/cli/webhook/dryRun.ts
+++ b/src/cli/webhook/dryRun.ts
@@ -62,13 +62,11 @@ export const handler = async (argv: Arguments<WebhookDryRunArgs>) => {
     },
   ]);
 
-  const { instance } = argv;
-  const endpoint = `${instance}/graphql/`;
   const headers = await Config.getBearerHeader();
 
   try {
     const { data }: any = await got
-      .post(endpoint, {
+      .post(argv.instance, {
         headers,
         json: {
           query: print(WebhookDryRun),

--- a/src/cli/webhook/edit.ts
+++ b/src/cli/webhook/edit.ts
@@ -29,7 +29,6 @@ export const builder = NoCommandBuilderSetup;
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
   const { environment, webhookID, instance } = argv;
-  const endpoint = `${instance}/graphql/`;
   const headers = await Config.getBearerHeader();
 
   const query = `query getWebhook($id: ID!) {
@@ -51,7 +50,7 @@ export const handler = async (argv: Arguments<Options>) => {
   const {
     data: { webhook },
   } = await got
-    .post(endpoint, {
+    .post(instance, {
       headers,
       json: {
         query,
@@ -94,7 +93,7 @@ export const handler = async (argv: Arguments<Options>) => {
   ]);
 
   await got
-    .post(endpoint, {
+    .post(instance, {
       headers,
       json: {
         query: print(WebhookUpdate),

--- a/src/cli/webhook/list.ts
+++ b/src/cli/webhook/list.ts
@@ -17,12 +17,11 @@ export const desc = 'List webhooks for an environment';
 
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
-  const { instance } = argv;
-  const endpoint = `${instance}/graphql/`;
+  const { instance, json } = argv;
   const headers = await Config.getBearerHeader();
 
   const { data }: any = await got
-    .post(endpoint, {
+    .post(instance, {
       headers,
       json: {
         query: print(WebhookList),
@@ -30,7 +29,7 @@ export const handler = async (argv: Arguments<Options>) => {
     })
     .json();
 
-  const apps = getAppsFromResult(data, argv.json);
+  const apps = getAppsFromResult(data, json);
 
   const webhookList = apps.map((app: any) => app.node.webhooks).flat();
 
@@ -50,7 +49,7 @@ export const handler = async (argv: Arguments<Options>) => {
     process.exit(0);
   }
 
-  if (argv.json) {
+  if (json) {
     console.log(JSON.stringify(webhookList, null, 2));
     return;
   }

--- a/src/cli/webhook/update.ts
+++ b/src/cli/webhook/update.ts
@@ -17,19 +17,17 @@ export const desc = 'Update webhooks for an environment';
 
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
-  const { instance } = argv;
-  const endpoint = `${instance}/graphql/`;
-  await updateWebhook(endpoint, argv.json);
+  await updateWebhook(argv.instance, argv.json);
 };
 
 export const updateWebhook = async (
-  endpoint: string,
+  instance: string,
   json: boolean | undefined,
 ) => {
   const headers = await Config.getBearerHeader();
 
   const { data }: any = await got
-    .post(endpoint, {
+    .post(instance, {
       headers,
       json: {
         query: print(WebhookList),
@@ -63,7 +61,7 @@ export const updateWebhook = async (
       for (const { id, targetUrl } of webhooks) {
         const url = new URL(targetUrl);
         const newTargetUrl = `${webhooksDomain}${url.pathname}`;
-        await runUpdateWebhook(headers, endpoint, id, newTargetUrl);
+        await runUpdateWebhook(headers, instance, id, newTargetUrl);
       }
     }
 
@@ -83,7 +81,7 @@ export const updateWebhook = async (
         });
 
         const spinner = ora('Updating...').start();
-        await runUpdateWebhook(headers, endpoint, id, newTargetUrl);
+        await runUpdateWebhook(headers, instance, id, newTargetUrl);
         spinner.succeed('Updated');
       }
     }
@@ -92,12 +90,12 @@ export const updateWebhook = async (
 
 const runUpdateWebhook = async (
   headers: Record<string, string>,
-  endpoint: string,
+  instance: string,
   id: string,
   targetUrl: string | null,
 ) => {
   const { errors }: any = await got
-    .post(endpoint, {
+    .post(instance, {
       headers,
       json: {
         query: print(WebhookUpdate),

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -32,10 +32,9 @@ export const doSaleorAppDelete = async (argv: any) => {
   const headers = await Config.getBearerHeader();
 
   const { instance, appId: app } = argv;
-  const endpoint = `${instance}/graphql/`;
 
   const { data }: any = await got
-    .post(endpoint, {
+    .post(instance, {
       headers,
       json: {
         query: print(AppDelete),
@@ -53,7 +52,6 @@ export const doSaleorAppDelete = async (argv: any) => {
 
 export const doSaleorAppInstall = async (argv: any) => {
   const { instance } = argv;
-  const endpoint = `${instance}/graphql/`;
   const headers = await Config.getBearerHeader();
 
   if (!argv.manifestURL) {
@@ -87,7 +85,7 @@ export const doSaleorAppInstall = async (argv: any) => {
 
   if (!argv.viaDashboard) {
     const { data, errors }: any = await got
-      .post(endpoint, {
+      .post(instance, {
         headers,
         json: {
           query: print(AppInstall),
@@ -139,11 +137,10 @@ export const doSaleorAppInstall = async (argv: any) => {
 };
 
 const waitForAppInstallation = async (argv: any, id: string) => {
-  const endpoint = `${argv.instance}/graphql/`;
   const headers = await Config.getBearerHeader();
 
   const { data, errors }: any = await got
-    .post(endpoint, {
+    .post(argv.instance, {
       headers,
       json: {
         query: print(AppsInstallations),
@@ -180,11 +177,10 @@ export const buildManifestURL = (path: string, origin: string) => {
 };
 
 export const fetchSaleorAppList = async (argv: any) => {
-  const endpoint = `${argv.instance}/graphql/`;
   const headers = await Config.getBearerHeader();
 
   const { data, errors }: any = await got
-    .post(endpoint, {
+    .post(argv.instance, {
       headers,
       json: {
         query: print(GetApps),

--- a/src/lib/environment.test.ts
+++ b/src/lib/environment.test.ts
@@ -20,7 +20,7 @@ const argv = {
   token: 'XYZ',
   organization: 'test_org',
   environment: 'test',
-  instance: 'https://test-environment.test.saleor.cloud',
+  instance: 'https://test-environment.test.saleor.cloud/graphql/',
 } as Arguments<Options>;
 
 const handlers = [
@@ -52,12 +52,11 @@ describe('getEnvironment', () => {
   });
 });
 
-describe('get Saleor API endpoint', () => {
-  it('should return the environment\'s graphql endpoint', async () => {
+describe('get Saleor API instance', () => {
+  it('should return the environment\'s graphql instance', async () => {
     const { instance } = argv;
-    const endpoint = `${instance}/graphql/`;
 
-    expect(endpoint).toEqual(
+    expect(instance).toEqual(
       'https://test-environment.test.saleor.cloud/graphql/',
     );
   });

--- a/src/lib/queryEnvironment.ts
+++ b/src/lib/queryEnvironment.ts
@@ -21,7 +21,10 @@ const isHttpBasicAuthProtected = (response: Response) => {
 const getAuth = async (argv: Arguments<Options>) => {
   console.log('The selected environment is restricted with Basic Auth');
   const { token } = await Config.get();
-  const user = (await GET(API.User, { token })) as User;
+  const user = (await GET(API.User, {
+    token,
+    instance: argv.instance,
+  })) as User;
 
   const data = await Enquirer.prompt<{ username: string; password: string }>([
     {
@@ -66,15 +69,15 @@ const checkAuth = async (endpoint: string, argv: Arguments<Options>) => {
 };
 
 export const POST = async (
-  endpoint: string,
+  instance: string,
   headers: Record<string, string>,
   json: Record<string, unknown>,
   argv: Arguments<Options>,
 ) => {
-  const auth = await checkAuth(endpoint, argv);
+  const auth = await checkAuth(instance, argv);
 
   const { data } = await got
-    .post(endpoint, {
+    .post(instance, {
       headers: {
         ...headers,
         ...auth,

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -200,12 +200,10 @@ const createPrompt = async <T>({
 };
 
 export const makeRequestAppList = async (argv: Options) => {
-  const { instance } = argv;
-  const endpoint = `${instance}/graphql/`;
   const headers = await Config.getBearerHeader();
 
   const { data, errors }: any = await got
-    .post(endpoint, {
+    .post(argv.instance, {
       headers,
       json: { query: gqlPrint(GetApps) },
     })
@@ -258,14 +256,11 @@ export const promptWebhook = async (argv: Options) =>
     name: 'webhookID',
     message: 'Select a Webhook',
     fetcher: async () => {
-      const { instance } = argv;
-      const endpoint = `${instance}/graphql/`;
       const headers = await Config.getBearerHeader();
-
-      const { app: appID } = argv;
+      const { app: appID, instance } = argv;
 
       const { data, errors }: any = await got
-        .post(endpoint, {
+        .post(instance, {
           headers,
           json: {
             query: gqlPrint(GetAppById),

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -119,7 +119,7 @@ export const useInstanceAttacher = async (argv: Options) => {
 
   return {
     ...argv,
-    instance: `https://${instance.domain}`,
+    instance: `https://${instance.domain}/graphql/`,
   };
 };
 
@@ -353,11 +353,8 @@ mutation login($email: String!, $password: String!) {
       message: 'Your password?',
     });
 
-    const { instance } = argv;
-    const endpoint = `${instance}/graphql/`;
-
     const { data, errors }: any = await got
-      .post(endpoint, {
+      .post(argv.instance, {
         json: {
           query: doLogin,
           variables: { email, password },

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ export interface BaseOptions {
   token?: string;
   organization?: string;
   environment?: string;
-  instance?: string;
+  instance: string;
   json?: boolean;
 }
 

--- a/test/functional/environment/origins.test.ts
+++ b/test/functional/environment/origins.test.ts
@@ -21,8 +21,8 @@ describe('update trusted origins in environment', async () => {
       'env',
       'origins',
       envKey,
-      '--origin="https://example.com"',
-      '--origin="https://test.com"',
+      '--origins="https://example.com"',
+      '--origins="https://test.com"',
       `--organization=${testOrganization}`,
     ];
 


### PR DESCRIPTION
## I want to merge this PR because 

- it changes the` instance` URL to contain `/graphql/` suffix for the Saleor Cloud environments. This way both custom `instance` passed as argument and the instance based on the Cloud indicates a graphql endpoint.
- it extends commands with `examples `  

## Related (issues, PRs, topics)

- NA

## Steps to test feature

- 

## I have:

- [x] Tested it locally and it doesn't break existing features
- [x] Added documentation if public changes are introduced
- [x] Added tests for my code
