### PR TITLE
Improve the `storefront create` output

### DIFF
--- a/src/cli/storefront/create.ts
+++ b/src/cli/storefront/create.ts
@@ -18,6 +18,7 @@ import {
   checkPnpmPresence,
   getSortedServices,
   obfuscateArgv,
+  println,
   printlnSuccess,
 } from '../../lib/util.js';
 import {
@@ -216,15 +217,32 @@ export const createStorefront = async (argv: Arguments<StoreCreate>) => {
 
   spinner.succeed(
     chalk(
-      'Your Saleor Storefront is ready in the',
+      'Your Saleor Storefront Example is ready in the',
       chalk.yellow(target),
       'directory\n',
     ),
   );
 
-  console.log('  To start your application:\n');
-  console.log(`    cd ${target}`);
-  console.log('    pnpm dev');
+  if (!instance) {
+    println(chalk.bold('  To finalize prepare the `.env` file:\n'));
+    println(`    cd ${target}`);
+    println('    cp .env.example .env');
+    println(
+      '    set NEXT_PUBLIC_SALEOR_API_URL value to your Saleor GraphQL endpoint URL\n',
+    );
+  }
+
+  println(chalk.bold('  To setup payments:\n'));
+  println('    install and configure the Saleor payment App in your dashboard');
+  if ((instance || '').includes('saleor.cloud/graphql/')) {
+    println(`    ${instance.replace('graphql/', '')}dashboard/apps/`);
+  }
+
+  println(
+    chalk('\n', chalk.bold(' To start your Saleor Storefront Example:\n')),
+  );
+  println(`    cd ${target}`);
+  println('    pnpm dev\n');
 };
 
 const getFolderName = async (name: string): Promise<string> => {


### PR DESCRIPTION
## I want to merge this PR because 

- it extends the `storefront create` command with additional output to help finalization of the setup process

![CleanShot 2023-10-26 at 17 07 11@2x](https://github.com/saleor/cli/assets/779644/9982c114-1791-432d-9c0c-cc6034673685)

![CleanShot 2023-10-26 at 17 07 45@2x](https://github.com/saleor/cli/assets/779644/921a3ce1-7424-49f6-adf8-cc50c7cc79d4)

## Related (issues, PRs, topics)

- NA

## Steps to test feature

- `saleor storefront create`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
