### PR TITLE
Allow to skip webhooks update when using `env create`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -592,19 +592,20 @@ Positionals:
   name  name for the new environment  [string]
 
 Options:
-      --json             Output the data as JSON  [boolean] [default: false]
-      --short            Output data as text  [boolean] [default: false]
-  -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
-      --project          create this environment in this project  [string]
-      --database         specify how to populate the database  [string]
-      --saleor           specify the Saleor version  [string]
-      --domain           specify the domain for the environment  [string]
-      --login            specify the API Basic Auth login  [string]
-      --pass             specify the API Basic Auth password  [string]
-      --restore-from     specify snapshot id to restore the database from  [string]
-      --skip-restrict    skip Basic Auth restriction prompt  [boolean]
-  -V, --version          Show version number  [boolean]
-  -h, --help             Show help  [boolean]
+      --json                  Output the data as JSON  [boolean] [default: false]
+      --short                 Output data as text  [boolean] [default: false]
+  -u, --instance, --url       Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
+      --project               create this environment in this project  [string]
+      --database              specify how to populate the database  [string]
+      --saleor                specify the Saleor version  [string]
+      --domain                specify the domain for the environment  [string]
+      --login                 specify the API Basic Auth login  [string]
+      --pass                  specify the API Basic Auth password  [string]
+      --restore-from          specify snapshot id to restore the database from  [string]
+      --skip-webhooks-update  use with `restore-from` option, skip webhooks update prompt when restoring from snapshot  [boolean]
+      --skip-restrict         skip Basic Auth restriction prompt  [boolean]
+  -V, --version               Show version number  [boolean]
+  -h, --help                  Show help  [boolean]
 
 Examples:
   saleor env create my-environment

--- a/docs/cli/commands/environment.mdx
+++ b/docs/cli/commands/environment.mdx
@@ -150,19 +150,20 @@ Positionals:
   name  name for the new environment  [string]
 
 Options:
-      --json             Output the data as JSON  [boolean] [default: false]
-      --short            Output data as text  [boolean] [default: false]
-  -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
-      --project          create this environment in this project  [string]
-      --database         specify how to populate the database  [string]
-      --saleor           specify the Saleor version  [string]
-      --domain           specify the domain for the environment  [string]
-      --login            specify the API Basic Auth login  [string]
-      --pass             specify the API Basic Auth password  [string]
-      --restore-from     specify snapshot id to restore the database from  [string]
-      --skip-restrict    skip Basic Auth restriction prompt  [boolean]
-  -V, --version          Show version number  [boolean]
-  -h, --help             Show help  [boolean]
+      --json                  Output the data as JSON  [boolean] [default: false]
+      --short                 Output data as text  [boolean] [default: false]
+  -u, --instance, --url       Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
+      --project               create this environment in this project  [string]
+      --database              specify how to populate the database  [string]
+      --saleor                specify the Saleor version  [string]
+      --domain                specify the domain for the environment  [string]
+      --login                 specify the API Basic Auth login  [string]
+      --pass                  specify the API Basic Auth password  [string]
+      --restore-from          specify snapshot id to restore the database from  [string]
+      --skip-webhooks-update  use with `restore-from` option, skip webhooks update prompt when restoring from snapshot  [boolean]
+      --skip-restrict         skip Basic Auth restriction prompt  [boolean]
+  -V, --version               Show version number  [boolean]
+  -h, --help                  Show help  [boolean]
 
 Examples:
   saleor env create my-environment

--- a/src/cli/env/create.ts
+++ b/src/cli/env/create.ts
@@ -29,6 +29,7 @@ interface CommandOptions extends Options {
   pass?: string;
   restore: boolean;
   restoreFrom: string;
+  skipWebhooksUpdate: boolean;
   skipRestrict: boolean;
 }
 
@@ -72,6 +73,11 @@ export const builder: CommandBuilder = (_) =>
       type: 'string',
       desc: 'specify snapshot id to restore the database from',
     })
+    .option('skip-webhooks-update', {
+      type: 'boolean',
+      demandOption: false,
+      desc: 'use with `restore-from` option, skip webhooks update prompt when restoring from snapshot',
+    })
     .option('skip-restrict', {
       type: 'boolean',
       desc: 'skip Basic Auth restriction prompt',
@@ -96,6 +102,7 @@ export const handler = async (argv: Arguments<CommandOptions>) => {
     const { update } = await Enquirer.prompt<{ update: string }>({
       type: 'confirm',
       name: 'update',
+      skip: !!argv.skipWebhooksUpdate,
       message: 'Would you like to update webhooks targetUrl',
     });
 


### PR DESCRIPTION
## I want to merge this PR because 

- it allows to skip webhooks update prompt when creating a new environment using the `restore-from` option

## Related (issues, PRs, topics)

- #700 

## Steps to test feature

- `saleor-dist env create ... --project=... --database=snapshot --restore-from=... --saleor=saleor-master-staging --domain=...  --skip-restrict --skip-webhooks-update`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [x] Added documentation if public changes are introduced
- [ ] Added tests for my code
