### PR TITLE
Read token from environment variable

### DIFF
--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -43,26 +43,33 @@ export const useToken = async ({ token }: Options) => {
     const config = await Config.get();
     const { token: configToken } = config;
 
+    if (process.env.SALEOR_CLI_TOKEN) {
+      debug('token read from env');
+      opts = { ...opts, token: `TOKEN ${process.env.SALEOR_CLI_TOKEN}` };
+      return opts;
+    }
+
     if (configToken) {
       debug('token read from file');
       opts = { ...opts, token: configToken };
-    } else {
-      console.error(chalk.red('\nYou are not logged in\n'));
-      console.error(
-        chalk(
-          'If you have an account - login using',
-          chalk.bold.green('saleor login'),
-        ),
-      );
-      console.error(
-        chalk(
-          'If you don\'t have an account - register using',
-          chalk.bold.green('saleor register'),
-        ),
-      );
-
-      process.exit(1);
+      return opts;
     }
+
+    console.error(chalk.red('\nYou are not logged in\n'));
+    console.error(
+      chalk(
+        'If you have an account - login using',
+        chalk.bold.green('saleor login'),
+      ),
+    );
+    console.error(
+      chalk(
+        'If you don\'t have an account - register using',
+        chalk.bold.green('saleor register'),
+      ),
+    );
+
+    process.exit(1);
   }
 
   return opts;


### PR DESCRIPTION
## I want to merge this PR because 

- it allows the use `SALEOR_CLI_TOKEN` variable for communication with Saleor Cloud. It can be useful in CI or headless environments. This environment variable takes precedence over the config file.

## Related (issues, PRs, topics)

- NA

## Steps to test feature

- set `SALEOR_CLI_TOKEN` environment variable 

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
