### PR TITLE
Use organization backup endpoint

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -886,7 +886,7 @@ saleor backup [command]
 Manage Saleor Cloud backups
 
 Commands:
-  saleor backup list [key|environment]    List backups of the environment
+  saleor backup list                      List backups of the organization
   saleor backup create [name]             Create a new backup
   saleor backup show [backup|backup-key]  Show a specific backup
   saleor backup remove <key|backup>       Remove the backup
@@ -909,20 +909,22 @@ $ saleor backup list --help
 Help output:
 
 ```
-saleor backup list [key|environment]
+saleor backup list
 
-List backups of the environment
+List backups of the organization
 
 Options:
       --json             Output the data as JSON  [boolean] [default: false]
       --short            Output data as text  [boolean] [default: false]
   -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
+      --name             filter the output for name for backup  [string]
+      --latest           show only the latest backup  [boolean] [default: false]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
 
 Examples:
   saleor backup list
-  saleor backup list --organization="organization-slug" --environment="env-id-or-name"
+  saleor backup list --organization="organization-slug"
 ```
 
 #### backup create
@@ -948,7 +950,7 @@ Options:
 
 Examples:
   saleor backup create
-  saleor backup create my-backup --environment=env-id-or-name
+  saleor backup create my-backup --organization="organization-slug"
 ```
 
 #### backup show
@@ -973,8 +975,9 @@ Options:
 
 Examples:
   saleor backup show
+  saleor backup show
   saleor backup show backup-key
-  saleor backup show backup-key --organization="organization-slug" --environment="env-id-or-name"
+  saleor backup show backup-key --organization="organization-slug"
 ```
 
 #### backup remove
@@ -1004,7 +1007,7 @@ Options:
 Examples:
   saleor backup remove
   saleor backup remove backup-key --force
-  saleor backup remove backup-key --force --organization="organization-slug" --environment="env-id-or-name"
+  saleor backup remove backup-key --force --organization="organization-slug"
 ```
 
 #### backup restore

--- a/docs/README.md
+++ b/docs/README.md
@@ -539,7 +539,7 @@ Options:
 
 Examples:
   saleor env clear my-environment
-  saleor env clear my-environment --organization=organization-slug
+  saleor env clear my-environment --organization="organization-slug"
 ```
 
 #### environment cors
@@ -609,8 +609,8 @@ Options:
 
 Examples:
   saleor env create my-environment
-  saleor env create my-environment --project=project-name --database=sample --saleor=saleor-master-staging --domain=project-domain --skip-restrict
-  saleor env create my-environment --organization=organization-slug --project=project-name --database=sample --saleor=saleor-master-staging --domain=project-domain --skip-restrict
+  saleor env create my-environment --project="project-name" --database="sample" --saleor="saleor-master-staging" --domain="project-domain" --skip-restrict
+  saleor env create my-environment --organization="organization-slug" --project="project-name" --database="sample" --saleor="saleor-master-staging" --domain="project-domain" --skip-restrict
 ```
 
 #### environment list
@@ -1638,7 +1638,7 @@ Options:
 Examples:
   saleor app install --manifest-URL="https://my-saleor-app.com/api/manifest
   saleor app install --manifest-URL="https://my-saleor-app.com/api/manifest --app-name="Saleor app"
-  saleor app install --organization=organization-slug --environment=env-id-or-name --app-name="Saleor app" --manifest-URL="https://my-saleor-app.com/api/manifest
+  saleor app install --organization="organization-slug" --environment="env-id-or-name" --app-name="Saleor app" --manifest-URL="https://my-saleor-app.com/api/manifest"
 ```
 
 #### app uninstall
@@ -1666,7 +1666,7 @@ Options:
 
 Examples:
   saleor app uninstall app-id
-  saleor app uninstall app-id --organization=organization-slug --environment=env-id-or-name
+  saleor app uninstall app-id --organization="organization-slug" --environment="env-id-or-name"
 ```
 
 #### app create
@@ -1694,8 +1694,8 @@ Options:
   -h, --help             Show help  [boolean]
 
 Examples:
-  saleor app create --name=my-saleor-app --permissions=MANAGE_USERS --permissions=MANAGE_STAFF
-  saleor app create --name=my-saleor-app --organization=organization-slug --environment=env-id-or-name --permissions=MANAGE_USERS --permissions=MANAGE_STAFF
+  saleor app create --name="my saleor app" --permissions=MANAGE_USERS --permissions=MANAGE_STAFF
+  saleor app create --name="my saleor app" --organization="organization-slug" --environment="env-id-or-name" --permissions=MANAGE_USERS --permissions=MANAGE_STAFF
 ```
 
 #### app tunnel
@@ -1727,8 +1727,8 @@ Options:
 Examples:
   saleor app tunnel --name="Custom name"
   saleor app tunnel --force-install
-  saleor app tunnel --manifest-path=/app/manifest
-  saleor app tunnel --organization=organization-slug --environment=env-id-or-name
+  saleor app tunnel --manifest-path="/app/manifest"
+  saleor app tunnel --organization="organization-slug" --environment="env-id-or-name"
 ```
 
 #### app token
@@ -1781,8 +1781,8 @@ Options:
   -h, --help             Show help  [boolean]
 
 Examples:
-  saleor app permission --app-id=APP-ID --permissions=MANAGE_USERS --permissions=MANAGE_STAFF
-  saleor app permission --organization=organization-slug --environment=env-id-or-name --app-id=APP-ID --permissions=MANAGE_USERS --permissions=MANAGE_STAFF
+  saleor app permission --app-id="app-id" --permissions=MANAGE_USERS --permissions=MANAGE_STAFF
+  saleor app permission --organization="organization-slug" --environment="env-id-or-name" --app-id="app-id" --permissions=MANAGE_USERS --permissions=MANAGE_STAFF
 ```
 
 #### app template
@@ -1837,7 +1837,7 @@ Options:
 
 Examples:
   saleor app remove
-  saleor app remove --app-id=APP-ID --environment=env-id-or-name --force
+  saleor app remove --app-id="app-id" --environment="env-id-or-name" --force
 ```
 
 ### vercel

--- a/docs/cli/commands/app.mdx
+++ b/docs/cli/commands/app.mdx
@@ -84,7 +84,7 @@ Options:
 Examples:
   saleor app install --manifest-URL="https://my-saleor-app.com/api/manifest
   saleor app install --manifest-URL="https://my-saleor-app.com/api/manifest --app-name="Saleor app"
-  saleor app install --organization=organization-slug --environment=env-id-or-name --app-name="Saleor app" --manifest-URL="https://my-saleor-app.com/api/manifest
+  saleor app install --organization="organization-slug" --environment="env-id-or-name" --app-name="Saleor app" --manifest-URL="https://my-saleor-app.com/api/manifest"
 ```
 
 #### app uninstall
@@ -112,7 +112,7 @@ Options:
 
 Examples:
   saleor app uninstall app-id
-  saleor app uninstall app-id --organization=organization-slug --environment=env-id-or-name
+  saleor app uninstall app-id --organization="organization-slug" --environment="env-id-or-name"
 ```
 
 #### app create
@@ -140,8 +140,8 @@ Options:
   -h, --help             Show help  [boolean]
 
 Examples:
-  saleor app create --name=my-saleor-app --permissions=MANAGE_USERS --permissions=MANAGE_STAFF
-  saleor app create --name=my-saleor-app --organization=organization-slug --environment=env-id-or-name --permissions=MANAGE_USERS --permissions=MANAGE_STAFF
+  saleor app create --name="my saleor app" --permissions=MANAGE_USERS --permissions=MANAGE_STAFF
+  saleor app create --name="my saleor app" --organization="organization-slug" --environment="env-id-or-name" --permissions=MANAGE_USERS --permissions=MANAGE_STAFF
 ```
 
 #### app tunnel
@@ -173,8 +173,8 @@ Options:
 Examples:
   saleor app tunnel --name="Custom name"
   saleor app tunnel --force-install
-  saleor app tunnel --manifest-path=/app/manifest
-  saleor app tunnel --organization=organization-slug --environment=env-id-or-name
+  saleor app tunnel --manifest-path="/app/manifest"
+  saleor app tunnel --organization="organization-slug" --environment="env-id-or-name"
 ```
 
 #### app token
@@ -227,8 +227,8 @@ Options:
   -h, --help             Show help  [boolean]
 
 Examples:
-  saleor app permission --app-id=APP-ID --permissions=MANAGE_USERS --permissions=MANAGE_STAFF
-  saleor app permission --organization=organization-slug --environment=env-id-or-name --app-id=APP-ID --permissions=MANAGE_USERS --permissions=MANAGE_STAFF
+  saleor app permission --app-id="app-id" --permissions=MANAGE_USERS --permissions=MANAGE_STAFF
+  saleor app permission --organization="organization-slug" --environment="env-id-or-name" --app-id="app-id" --permissions=MANAGE_USERS --permissions=MANAGE_STAFF
 ```
 
 #### app template
@@ -283,5 +283,5 @@ Options:
 
 Examples:
   saleor app remove
-  saleor app remove --app-id=APP-ID --environment=env-id-or-name --force
+  saleor app remove --app-id="app-id" --environment="env-id-or-name" --force
 ```

--- a/docs/cli/commands/backup.mdx
+++ b/docs/cli/commands/backup.mdx
@@ -16,7 +16,7 @@ saleor backup [command]
 Manage Saleor Cloud backups
 
 Commands:
-  saleor backup list [key|environment]    List backups of the environment
+  saleor backup list                      List backups of the organization
   saleor backup create [name]             Create a new backup
   saleor backup show [backup|backup-key]  Show a specific backup
   saleor backup remove <key|backup>       Remove the backup
@@ -39,20 +39,22 @@ $ saleor backup list --help
 Help output:
 
 ```
-saleor backup list [key|environment]
+saleor backup list
 
-List backups of the environment
+List backups of the organization
 
 Options:
       --json             Output the data as JSON  [boolean] [default: false]
       --short            Output data as text  [boolean] [default: false]
   -u, --instance, --url  Saleor instance API URL (must start with the protocol, i.e. https:// or http://)  [string]
+      --name             filter the output for name for backup  [string]
+      --latest           show only the latest backup  [boolean] [default: false]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
 
 Examples:
   saleor backup list
-  saleor backup list --organization="organization-slug" --environment="env-id-or-name"
+  saleor backup list --organization="organization-slug"
 ```
 
 #### backup create
@@ -78,7 +80,7 @@ Options:
 
 Examples:
   saleor backup create
-  saleor backup create my-backup --environment=env-id-or-name
+  saleor backup create my-backup --organization="organization-slug"
 ```
 
 #### backup show
@@ -103,8 +105,9 @@ Options:
 
 Examples:
   saleor backup show
+  saleor backup show
   saleor backup show backup-key
-  saleor backup show backup-key --organization="organization-slug" --environment="env-id-or-name"
+  saleor backup show backup-key --organization="organization-slug"
 ```
 
 #### backup remove
@@ -134,7 +137,7 @@ Options:
 Examples:
   saleor backup remove
   saleor backup remove backup-key --force
-  saleor backup remove backup-key --force --organization="organization-slug" --environment="env-id-or-name"
+  saleor backup remove backup-key --force --organization="organization-slug"
 ```
 
 #### backup restore

--- a/docs/cli/commands/environment.mdx
+++ b/docs/cli/commands/environment.mdx
@@ -97,7 +97,7 @@ Options:
 
 Examples:
   saleor env clear my-environment
-  saleor env clear my-environment --organization=organization-slug
+  saleor env clear my-environment --organization="organization-slug"
 ```
 
 #### environment cors
@@ -167,8 +167,8 @@ Options:
 
 Examples:
   saleor env create my-environment
-  saleor env create my-environment --project=project-name --database=sample --saleor=saleor-master-staging --domain=project-domain --skip-restrict
-  saleor env create my-environment --organization=organization-slug --project=project-name --database=sample --saleor=saleor-master-staging --domain=project-domain --skip-restrict
+  saleor env create my-environment --project="project-name" --database="sample" --saleor="saleor-master-staging" --domain="project-domain" --skip-restrict
+  saleor env create my-environment --organization="organization-slug" --project="project-name" --database="sample" --saleor="saleor-master-staging" --domain="project-domain" --skip-restrict
 ```
 
 #### environment list

--- a/src/cli/app/create.ts
+++ b/src/cli/app/create.ts
@@ -32,11 +32,11 @@ export const builder: CommandBuilder = (_) =>
       desc: 'The array of permissions',
     })
     .example(
-      'saleor app create --name=my-saleor-app --permissions=MANAGE_USERS --permissions=MANAGE_STAFF',
+      'saleor app create --name="my saleor app" --permissions=MANAGE_USERS --permissions=MANAGE_STAFF',
       '',
     )
     .example(
-      'saleor app create --name=my-saleor-app --organization=organization-slug --environment=env-id-or-name --permissions=MANAGE_USERS --permissions=MANAGE_STAFF',
+      'saleor app create --name="my saleor app" --organization="organization-slug" --environment="env-id-or-name" --permissions=MANAGE_USERS --permissions=MANAGE_STAFF',
       '',
     );
 

--- a/src/cli/app/install.ts
+++ b/src/cli/app/install.ts
@@ -39,7 +39,7 @@ export const builder: CommandBuilder = (_) =>
       '',
     )
     .example(
-      'saleor app install --organization=organization-slug --environment=env-id-or-name --app-name="Saleor app" --manifest-URL="https://my-saleor-app.com/api/manifest',
+      'saleor app install --organization="organization-slug" --environment="env-id-or-name" --app-name="Saleor app" --manifest-URL="https://my-saleor-app.com/api/manifest"',
       '',
     );
 

--- a/src/cli/app/permission.ts
+++ b/src/cli/app/permission.ts
@@ -33,11 +33,11 @@ export const builder: CommandBuilder = (_) =>
       desc: 'The array of permissions',
     })
     .example(
-      'saleor app permission --app-id=APP-ID --permissions=MANAGE_USERS --permissions=MANAGE_STAFF',
+      'saleor app permission --app-id="app-id" --permissions=MANAGE_USERS --permissions=MANAGE_STAFF',
       '',
     )
     .example(
-      'saleor app permission --organization=organization-slug --environment=env-id-or-name --app-id=APP-ID --permissions=MANAGE_USERS --permissions=MANAGE_STAFF',
+      'saleor app permission --organization="organization-slug" --environment="env-id-or-name" --app-id="app-id" --permissions=MANAGE_USERS --permissions=MANAGE_STAFF',
       '',
     );
 

--- a/src/cli/app/remove.ts
+++ b/src/cli/app/remove.ts
@@ -31,7 +31,7 @@ export const builder: CommandBuilder = (_) =>
     })
     .example('saleor app remove', '')
     .example(
-      'saleor app remove --app-id=APP-ID --environment=env-id-or-name --force',
+      'saleor app remove --app-id="app-id" --environment="env-id-or-name" --force',
       '',
     );
 

--- a/src/cli/app/tunnel.ts
+++ b/src/cli/app/tunnel.ts
@@ -52,9 +52,9 @@ export const builder: CommandBuilder = (_) =>
     })
     .example('saleor app tunnel --name="Custom name"', '')
     .example('saleor app tunnel --force-install', '')
-    .example('saleor app tunnel --manifest-path=/app/manifest', '')
+    .example('saleor app tunnel --manifest-path="/app/manifest"', '')
     .example(
-      'saleor app tunnel --organization=organization-slug --environment=env-id-or-name',
+      'saleor app tunnel --organization="organization-slug" --environment="env-id-or-name"',
       '',
     );
 

--- a/src/cli/app/uninstall.ts
+++ b/src/cli/app/uninstall.ts
@@ -30,7 +30,7 @@ export const builder: CommandBuilder = (_) =>
 
     .example('saleor app uninstall app-id', '')
     .example(
-      'saleor app uninstall app-id --organization=organization-slug --environment=env-id-or-name',
+      'saleor app uninstall app-id --organization="organization-slug" --environment="env-id-or-name"',
       '',
     );
 

--- a/src/cli/backup/create.ts
+++ b/src/cli/backup/create.ts
@@ -9,6 +9,7 @@ import {
   validateLength,
   waitForTask,
 } from '../../lib/util.js';
+import { useEnvironment } from '../../middleware/index.js';
 
 const debug = Debug('saleor-cli:backup:create');
 
@@ -22,7 +23,10 @@ export const builder: CommandBuilder = (_) =>
     desc: 'name for the new backup',
   })
     .example('saleor backup create', '')
-    .example('saleor backup create my-backup --environment=env-id-or-name', '');
+    .example(
+      'saleor backup create my-backup --organization="organization-slug"',
+      '',
+    );
 
 export const handler = async (argv: Arguments<any>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
@@ -41,7 +45,7 @@ export const handler = async (argv: Arguments<any>) => {
 
   debug(`Using the name: ${name}`);
 
-  const result = (await POST(API.Backup, argv, {
+  const result = (await POST(API.EnvironmentBackup, argv, {
     json: {
       name,
     },
@@ -56,3 +60,5 @@ export const handler = async (argv: Arguments<any>) => {
   );
   showResult(result, argv);
 };
+
+export const middlewares = [useEnvironment];

--- a/src/cli/backup/create.ts
+++ b/src/cli/backup/create.ts
@@ -9,7 +9,10 @@ import {
   validateLength,
   waitForTask,
 } from '../../lib/util.js';
-import { useEnvironment } from '../../middleware/index.js';
+import {
+  useBlockingTasksChecker,
+  useInstanceConnector,
+} from '../../middleware/index.js';
 
 const debug = Debug('saleor-cli:backup:create');
 
@@ -61,4 +64,4 @@ export const handler = async (argv: Arguments<any>) => {
   showResult(result, argv);
 };
 
-export const middlewares = [useEnvironment];
+export const middlewares = [useInstanceConnector, useBlockingTasksChecker];

--- a/src/cli/backup/index.ts
+++ b/src/cli/backup/index.ts
@@ -1,8 +1,3 @@
-import {
-  useBlockingTasksChecker,
-  useOrganization,
-  useToken,
-} from '../../middleware/index.js';
 import * as create from './create.js';
 import * as list from './list.js';
 import * as remove from './remove.js';
@@ -10,7 +5,8 @@ import * as restore from './restore.js';
 import * as show from './show.js';
 
 export default function (_: any) {
-  _.command([list, create, show, remove, restore])
-    .middleware([useToken, useOrganization, useBlockingTasksChecker])
-    .demandCommand(1, 'You need at least one command before moving on');
+  _.command([list, create, show, remove, restore]).demandCommand(
+    1,
+    'You need at least one command before moving on',
+  );
 }

--- a/src/cli/backup/index.ts
+++ b/src/cli/backup/index.ts
@@ -1,7 +1,7 @@
 import {
-  useAppConfig,
   useBlockingTasksChecker,
-  useInstanceConnector,
+  useOrganization,
+  useToken,
 } from '../../middleware/index.js';
 import * as create from './create.js';
 import * as list from './list.js';
@@ -11,6 +11,6 @@ import * as show from './show.js';
 
 export default function (_: any) {
   _.command([list, create, show, remove, restore])
-    .middleware([useAppConfig, useInstanceConnector, useBlockingTasksChecker])
+    .middleware([useToken, useOrganization, useBlockingTasksChecker])
     .demandCommand(1, 'You need at least one command before moving on');
 }

--- a/src/cli/backup/list.ts
+++ b/src/cli/backup/list.ts
@@ -10,6 +10,11 @@ import {
   verifyResultLength,
 } from '../../lib/util.js';
 import { Backup, Options } from '../../types.js';
+import {
+  useBlockingTasksChecker,
+  useOrganization,
+  useToken,
+} from '../../middleware/index.js';
 
 const debug = Debug('saleor-cli:backup:list');
 
@@ -83,3 +88,5 @@ export const handler = async (argv: Arguments<Options>) => {
     key: { minWidth: 2 },
   });
 };
+
+export const middlewares = [useToken, useOrganization, useBlockingTasksChecker];

--- a/src/cli/backup/remove.ts
+++ b/src/cli/backup/remove.ts
@@ -9,6 +9,11 @@ import {
   printlnSuccess,
 } from '../../lib/util.js';
 import { Options } from '../../types.js';
+import {
+  useBlockingTasksChecker,
+  useOrganization,
+  useToken,
+} from '../../middleware/index.js';
 
 const debug = Debug('saleor-cli:backup:remove');
 
@@ -45,3 +50,5 @@ export const handler = async (argv: Arguments<Options>) => {
     printlnSuccess(chalk.bold('Backup has been successfully removed'));
   }
 };
+
+export const middlewares = [useToken, useOrganization, useBlockingTasksChecker];

--- a/src/cli/backup/remove.ts
+++ b/src/cli/backup/remove.ts
@@ -28,7 +28,7 @@ export const builder: CommandBuilder = (_) =>
     .example('saleor backup remove', '')
     .example('saleor backup remove backup-key --force', '')
     .example(
-      'saleor backup remove backup-key --force --organization="organization-slug" --environment="env-id-or-name"',
+      'saleor backup remove backup-key --force --organization="organization-slug"',
       '',
     );
 

--- a/src/cli/backup/restore.ts
+++ b/src/cli/backup/restore.ts
@@ -10,7 +10,10 @@ import {
 } from '../../lib/util.js';
 import { Options } from '../../types.js';
 import { updateWebhook } from '../webhook/update.js';
-import { useEnvironment } from '../../middleware/index.js';
+import {
+  useBlockingTasksChecker,
+  useInstanceConnector,
+} from '../../middleware/index.js';
 
 const debug = Debug('saleor-cli:backup:restore');
 
@@ -80,4 +83,4 @@ const getBackup = async (argv: Arguments<Options>) => {
   return data;
 };
 
-export const middlewares = [useEnvironment];
+export const middlewares = [useInstanceConnector, useBlockingTasksChecker];

--- a/src/cli/backup/restore.ts
+++ b/src/cli/backup/restore.ts
@@ -10,6 +10,7 @@ import {
 } from '../../lib/util.js';
 import { Options } from '../../types.js';
 import { updateWebhook } from '../webhook/update.js';
+import { useEnvironment } from '../../middleware/index.js';
 
 const debug = Debug('saleor-cli:backup:restore');
 
@@ -78,3 +79,5 @@ const getBackup = async (argv: Arguments<Options>) => {
 
   return data;
 };
+
+export const middlewares = [useEnvironment];

--- a/src/cli/backup/show.ts
+++ b/src/cli/backup/show.ts
@@ -12,9 +12,10 @@ export const desc = 'Show a specific backup';
 
 export const builder: CommandBuilder = (_) =>
   _.example('saleor backup show', '')
+    .example('saleor backup show', '')
     .example('saleor backup show backup-key', '')
     .example(
-      'saleor backup show backup-key --organization="organization-slug" --environment="env-id-or-name"',
+      'saleor backup show backup-key --organization="organization-slug"',
       '',
     );
 

--- a/src/cli/backup/show.ts
+++ b/src/cli/backup/show.ts
@@ -4,6 +4,11 @@ import type { Arguments, CommandBuilder } from 'yargs';
 import { API, GET } from '../../lib/index.js';
 import { obfuscateArgv, showResult } from '../../lib/util.js';
 import { Options } from '../../types.js';
+import {
+  useBlockingTasksChecker,
+  useOrganization,
+  useToken,
+} from '../../middleware/index.js';
 
 const debug = Debug('saleor-cli:backup:show');
 
@@ -25,3 +30,5 @@ export const handler = async (argv: Arguments<Options>) => {
   const result = (await GET(API.Backup, argv)) as any;
   showResult(result, argv);
 };
+
+export const middlewares = [useToken, useOrganization, useBlockingTasksChecker];

--- a/src/cli/env/clear.ts
+++ b/src/cli/env/clear.ts
@@ -19,7 +19,7 @@ export const builder: CommandBuilder = (_) =>
   })
     .example('saleor env clear my-environment', '')
     .example(
-      'saleor env clear my-environment --organization=organization-slug',
+      'saleor env clear my-environment --organization="organization-slug"',
       '',
     );
 

--- a/src/cli/env/create.ts
+++ b/src/cli/env/create.ts
@@ -84,11 +84,11 @@ export const builder: CommandBuilder = (_) =>
     })
     .example('saleor env create my-environment', '')
     .example(
-      'saleor env create my-environment --project=project-name --database=sample --saleor=saleor-master-staging --domain=project-domain --skip-restrict',
+      'saleor env create my-environment --project="project-name" --database="sample" --saleor="saleor-master-staging" --domain="project-domain" --skip-restrict',
       '',
     )
     .example(
-      'saleor env create my-environment --organization=organization-slug --project=project-name --database=sample --saleor=saleor-master-staging --domain=project-domain --skip-restrict',
+      'saleor env create my-environment --organization="organization-slug" --project="project-name" --database="sample" --saleor="saleor-master-staging" --domain="project-domain" --skip-restrict',
       '',
     );
 

--- a/src/cli/storefront/deploy.ts
+++ b/src/cli/storefront/deploy.ts
@@ -25,7 +25,7 @@ export const builder: CommandBuilder = (_) =>
     })
     .example('saleor storefront deploy --no-github-prompt', '')
     .example(
-      'saleor storefront deploy --organization=organization-slug --environment=env-id-or-name --no-github-prompt',
+      'saleor storefront deploy --organization="organization-slug" --environment="env-id-or-name" --no-github-prompt',
       '',
     );
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -88,7 +88,6 @@ export const API: Record<string, DefaultURLPath> = {
   User: () => 'user',
   Organization: (_) => `organizations/${_.organization || ''}`,
   OrganizationPermissions: (_) => `organizations/${_.organization}/permissions`,
-  OrganizationBackups: (_) => `organizations/${_.organization}/backups`,
   UpgradeEnvironment: (_) =>
     `organizations/${_.organization}/environments/${_.environment}/upgrade`,
   Environment: (_) =>
@@ -102,10 +101,11 @@ export const API: Record<string, DefaultURLPath> = {
       _.params || ''
     }`,
   TaskStatus: (_) => `service/task-status/${_.task}`,
-  Backup: (_) =>
+  EnvironmentBackup: (_) =>
     `organizations/${_.organization}/environments/${_.environment}/backups/${
       _.backup || ''
     }`,
+  Backup: (_) => `organizations/${_.organization}/backups/${_.backup || ''}`,
   Restore: (_) =>
     `organizations/${_.organization}/environments/${_.environment}/restore`,
   Project: (_) => `organizations/${_.organization}/projects/${_.project || ''}`,

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -432,8 +432,7 @@ export const promptOrganizationBackup = async (argv: Options) =>
   createPrompt({
     name: 'backup',
     message: 'Select Snapshot',
-    fetcher: async () =>
-      GET(API.OrganizationBackups, argv) as Promise<Backup[]>,
+    fetcher: async () => GET(API.Backup, argv) as Promise<Backup[]>,
     extractor: (_: Backup) => ({
       name: chalk(
         chalk.bold(_.project.name),

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -186,6 +186,7 @@ const getEnvironmentByName = async (
   const environments = (await GET(API.Environment, {
     token,
     organization,
+    instance: '',
   })) as Environment[];
   const { key } =
     environments.filter(
@@ -210,6 +211,7 @@ export const verifyEnvironment = async (
       token,
       organization,
       environment,
+      instance: '',
     })) as Environment;
   } catch (error) {
     const key = await getEnvironmentByName(token, organization, environment);
@@ -219,6 +221,7 @@ export const verifyEnvironment = async (
         token,
         organization,
         environment: key,
+        instance: '',
       })) as Environment;
     } else {
       if (isNotFound(error)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,17 +185,18 @@ export interface Region {
   name: string;
 }
 
-export interface Backup {
+export type Backup = {
   key: string;
+  url: string;
+  project: Project;
   name: string;
-  project: {
-    slug: string;
-    name: string;
-    is_deleted: boolean;
-  };
-  saleor_version: string;
   created: string;
-}
+  environment_name: string;
+  environment_service_type: string;
+  saleor_version: string;
+  backup_type: string;
+  environment: string;
+};
 
 export interface Webhook {
   id: string;

--- a/test/functional/backup/restore.test.ts
+++ b/test/functional/backup/restore.test.ts
@@ -20,7 +20,6 @@ beforeAll(
       'backup',
       'create',
       backupName,
-      `--environment=${testEnvironmentName}`,
       `--organization=${testOrganization}`,
       '--json',
     ];
@@ -81,7 +80,6 @@ const getBackups = async () => {
   const params = [
     'backup',
     'list',
-    `--environment=${testEnvironmentName}`,
     `--organization=${testOrganization}`,
     '--json',
   ];
@@ -106,7 +104,6 @@ const removeBackups = async () => {
       'backup',
       'remove',
       backup.key,
-      `--environment=${testEnvironmentName}`,
       `--organization=${testOrganization}`,
       '--force',
     ];


### PR DESCRIPTION
## I want to merge this PR because 

- it switches backup commands to use the organization backup endpoint. It eliminates the need for the environment with those commands, making them more convenient.

## Related (issues, PRs, topics)

- #709 

## Steps to test feature

- `saleor backup list`
- `saleor backup create`
- `saleor backup remove`
- `saleor backup show`
- 

## I have:

- [x] Tested it locally and it doesn't break existing features
- [x] Added documentation if public changes are introduced
- [ ] Added tests for my code
